### PR TITLE
Update AutoRowHeightLayout.cs

### DIFF
--- a/Tree/AutoRowHeightLayout.cs
+++ b/Tree/AutoRowHeightLayout.cs
@@ -117,6 +117,9 @@ namespace Free.Controls.TreeView.Tree
 		public int GetRowAt(Point point)
 		{
 			int py=point.Y-_treeView.ColumnHeaderHeight;
+			if (py < 0)
+				return -1; 
+				
 			int y=0;
 			for(int i=_treeView.FirstVisibleRow; i<_treeView.RowCount; i++)
 			{

--- a/Tree/AutoRowHeightLayout.cs
+++ b/Tree/AutoRowHeightLayout.cs
@@ -117,7 +117,7 @@ namespace Free.Controls.TreeView.Tree
 		public int GetRowAt(Point point)
 		{
 			int py=point.Y-_treeView.ColumnHeaderHeight;
-			if (py < 0)
+			if (py<0)
 				return -1; 
 				
 			int y=0;


### PR DESCRIPTION
Avoid wasted enumeration of all row heights if the selection is on the header column for which the function is expected to return -1 (at the end of the enumeration). When dealing with large sets (several thousands lines) - the response time for tree sorting through column click is unreasonable due to this enumeration.